### PR TITLE
Abolish capital gains tax.

### DIFF
--- a/economy.md
+++ b/economy.md
@@ -12,7 +12,7 @@ What policies should we propose to maintain a competitive economy that provides 
 
 The personal income tax allowance will be set at the level of a full time living wage (currently £14,458.50 based on 252 working days of 7.5 hours per day at £7.65) and will rise inline with the living wage.
 
-The capital gains tax for individuals will be abolished, and all capital gains will be treated as income for tax purposes.
+The rate of capital gains tax for individuals will be harmonized with the rate of tax on earned income, and all allowances for each will be pooled, in order to ensure that work is rewarded and incentivised to the same extent as investment.
 
 ## Housing
 


### PR DESCRIPTION
Maybe a contentious one (and I'm perhaps being a terrible entryist trot here :-)), but I'd quite like to have a serious debate around why cap gains are taxed separately to income.

In my view, the seperation between the two is purely an ideological one, based in the capitalist assumption that 'wealth creators' should be especially rewarded for creating economic activity and therefore employment. A claim which I've never actually seen any real evidence for. If anyone can provide some, please do!

There's also practical reasons for this. Treating earning income as capital gains is a common tax-avoidance technique, and this would close that particular loophole in one fell swoop, as well as simplifying the tax system overall).
