### PR TITLE
No more airport expansion

### DIFF
--- a/transport.md
+++ b/transport.md
@@ -13,3 +13,7 @@ We will decrease emissions from road transport by setting a date beyond which no
 # National Infrastructure Organisations
 
 Network Rail, the Highways Agency, train operating companies and bus operating companies would all be required to become [National Infrastructure Organisations (NIOs)](infrastructure.html) under a policy to ensure that infrastructure which is essential to a functioning society is not solely operated for the benefit of private shareholders, but in the national interest.
+
+# End UK airport expansion
+
+There will be no further expansions (such as new runways or terminals) of any UK airports, and capacity shall be capped at roughly current levels.


### PR DESCRIPTION
Having a firm commitment to not expanding airports would send a strong signal that other, more sustainable forms of transport should be developed instead.
