### PR TITLE
Update transport.md

### DIFF
--- a/manifesto/transport.md
+++ b/manifesto/transport.md
@@ -43,4 +43,4 @@ Incentivise existing fuelling stations to install charging units for electric ve
 
 ## Railways
 
-Automate the national rail system (including London Underground) in order to increase throughput of the existing system and enhance safety. The automation plan should be created with rail unions to keep redundancies to a minimum throughout the process and avoid industrial action.
+Develop a long-term plan for complete electrification of the national rail network, and the replacement of diesel trains with electric multiple-units. This has the benefit of reduced emissions, improved efficiency, quieter and more comfortable trains. Alongside electrification, signalling should be updated to [ETCS](http://en.wikipedia.org/wiki/European_Train_Control_System) level 2 or 3 standard for improved safety and efficiency.


### PR DESCRIPTION
Removing paragraph on 'train automation' – this technology doesn't really exist outside of metro systems, partly because it wouldn't have a huge benefit on longer-distance routes (also because of higher speeds). Far more important to press ahead with electrification and signalling upgrades (which automatically stops the train from passing red signals).

London Underground is a devolved issue (to the GLA), and so shouldn't be discussed in this manifesto IMO.
