### PR TITLE
Reduce copyright term to Life + 50 years and lobby worldwide for Life + 25 years

### DIFF
--- a/manifesto/culture.md
+++ b/manifesto/culture.md
@@ -14,6 +14,8 @@ Reform copyright law to allow use for parody[^1].
 
 Reform copyright law to allow format-shifting of purchased media (for example, from CD to MP3)[^1].
 
+Immediately reduce the term of copyright from '70 years from the end of the calendar year of the author's death' to '50 years from the end of the calendar year of the author's death' (the minimum allowed by the [Berne Convention](http://en.wikipedia.org/wiki/Berne_Convention_for_the_Protection_of_Literary_and_Artistic_Works)) and lobby other states for a worldwide further reduction to 'life + 25 years'.
+
 ## Advertising
 
 Encourage the Advertising Standards Authority to tighten regulations around the use of pseudo-scientific language and terminology for the promotion of cosmetic, toiletry, food or other products, without sufficient evidence.


### PR DESCRIPTION
Reducing the length of copyright allows for more universal access to knowledge, as well enabling commercial activity around out-of-copyright works (e.g. printings, adaptations, etc).

Life + 50 years is achievable immediately without breaking the international Berne Convention.

Life + 25 years would, in my view, represent a fairer balance between allowing authors control of their work, and enabling wider access and use sooner after their death.

(Works by multiple authors such as films or anonymous authors might need separate provisions)
