### PR TITLE
Added remit: "Reducing inequality" for central bank

### DIFF
--- a/manifesto/economy.md
+++ b/manifesto/economy.md
@@ -68,6 +68,6 @@ In parallel, work at an international level to get rid of tax havens outside Bri
 
 We will instruct HM Treasury to produce a roadmap for the future of currency and the role of central banks in a world with non-state-issued digital currencies, such as Bitcoin.
 
-The central bank will be given the remit of 'reducing inequality' alongside its existing remits of maintaining inflation at 2% and promoting 'stability'. 
+The central bank will be required to consider the reduction of inequality (as measured by the GINI coefficient) when formulating monetary policy to balance its existing remit of maintaining price stability and inflation at 2%. 
 
 [^1]: [Stop Secret Contracts](http://stopsecretcontracts.org/)


### PR DESCRIPTION
This is up for discussion. It would create a deliberate confict of interest between restricting price inflation by lowering interest rates, and the unintended consequences of such actions - increasing asset inflation (e.g. property prices and share prices). Asset inflation is good for the wealthy because they hold assets, the poor don't hold assets so lose out - e.g. housing becomes more expensive. This is an example of "predistribution"; rather than allowing assets to rise exponentially and then taxing them, take action to restrict their rise in the first place.
