### PR TITLE
Replace extradition with UK based trials

### DIFF
--- a/manifesto/crime.md
+++ b/manifesto/crime.md
@@ -30,4 +30,8 @@ Implement rigorous protection regimes for whistleblowers.
 
 A review will be carried out into the composition of juries, especially for complex trials.
 
+## Extradition
+
+The UK will no longer extradite anyone to stand trial abroad. Alleged offences may have been committed while defendants were in the UK, or only in another country for a short time, and facing trial in an unfamiliar country without access to a support network that would available at home is too close to punishment rather than process. Instead, provisions will be made for 'international courts', where defendants can be tried without leaving the country. These international courts would host trials by countries which previously had extradition treaties with the UK.
+
 [^1]: [Wearing a Badge, and a Video Camera](http://mobile.nytimes.com/2013/04/07/business/wearable-video-cameras-for-police-officers.html?_r=0) - New York Times


### PR DESCRIPTION
I suspect this needs more thought (I'm guessing renegotiating extradition treaties is unlikely to be simple!) but I think the current system is unbalanced. The burden should be firmly on the prosecuting country, which has far larger resources at its disposal than the average defendant who, after all, is innocent until proven guilty.
Trying people in the UK seemed like a good starting point, especially given the nature of some crimes that have caused problems (committed in the UK, or where there are doubts about fair trials abroad, potential for onward extradition, etc.). The intention is, if the details can be made to work, to end up with a much quicker process (fewer fights against extradition) and one that doesn't unduly punish anyone before they are convicted.
Any thoughts?
Cheers, James
