### PR TITLE
Require a local connection

### DIFF
--- a/manifesto/democracy.md
+++ b/manifesto/democracy.md
@@ -49,7 +49,7 @@ Much apathy is focused around the perceived privilege of the political class. Th
 
 To deter time wasters, the current requirement of 10 nominations from the electorate to obtain candidacy will be increased to 20.
 
-Prospective parliamentary candidates must live or work in the constituency they wish to represent, and have done so for at least six months. This enforces the connection between representatives and their constituents and helps to disqualify candidates that are "flown in" by the party ahead of local choices.
+Prospective parliamentary candidates must have a good connection with the constituency they wish to represent. This enforces the connection between representatives and their constituents and helps to disqualify candidates that are "flown in" by the party ahead of local choices.
 
 ## European Elections
 


### PR DESCRIPTION
Constituency boundaries don't always reflect the boundaries of the people in a community. For example, someone's nearest constituency town may not be the town they regularly visit for leisure, or just identify with. Candidates will still need to show they spend a large part of their daily lives in the constituency they wish to represent under this change.
