### PR TITLE
Provide "maternity box" for newborn babies

### DIFF
--- a/manifesto/health.md
+++ b/manifesto/health.md
@@ -18,7 +18,7 @@ The NHS will not deny care to anyone for any reason, regardless of legal status,
 
 Ban parking charges in car parks serving NHS facilities. Only in cases where there is a serious, demonstrable abuse of parking by motorists not using the facilities will any regimes be permitted to curb such abuse, but these must never include a parking charge.
 
-A "maternity package" of useful items for newborn babies will be provided free to charge to mothers who register for NHS antenatal care before the end of the fourth month of pregnancy.
+A "maternity package" of useful items for newborn babies (similar to [the one offered in Finland](http://www.kela.fi/web/en/maternitypackage)) will be provided free to charge to mothers who register for NHS antenatal care before the end of the fourth month of pregnancy.
 
 ## Dentists
 


### PR DESCRIPTION
Modelled after the Finnish system. 
- http://www.kela.fi/web/en/maternitypackage
- http://www.buzzfeed.com/erinlarosa/heres-the-amazing-maternity-gift-box-all-new-parents-in-finl
- http://www.bbc.com/news/magazine-22751415
- http://indigenousjobsandtrainingreview.dpmc.gov.au/incentives-expectant-mothers-access-ante-natal-care
- http://www.upi.com/Health_News/2013/06/04/A-simple-cardboard-box-helped-Finland-reduce-infant-mortality/UPI-10921370394369/

A key component of this — that isn't always recognised in articles about it — is that it's conditional on registering for pre-natal care. This is widely credited as a key reason for Finland having one of the lowest rates of infant mortality in the world (and almost half that of the UK at present).
