### PR TITLE
Minutes etc should be published much quicker

### DIFF
--- a/manifesto/local_government.md
+++ b/manifesto/local_government.md
@@ -10,4 +10,4 @@ How do we improve and reinvigorate local government?
 
 ## Transparency
 
-Publish full minutes (or transcripts if available), audio recordings, and voting records from all local council meetings. Online publication should be performed within 24 hours. Software tools will be created to make this process simple.
+Publish full minutes (or transcripts if available), audio recordings, and voting records from all local council meetings. Online publication should be performed within 30 minutes. Software tools will be created to make this process simple.


### PR DESCRIPTION
Rather than allowing 24 hours for publishing of minutes/voting records etc., mandate that they should be published within 30 minutes. Changing to effectively real-time release is not only better for interested observers, but places the responsibility for doing it all with the meeting itself, rather than a separate function that happens later and can be thought about separately. This has precedent in Estonia.