### PR TITLE
Introduce overseas constituencies

### DIFF
--- a/manifesto/democracy.md
+++ b/manifesto/democracy.md
@@ -21,6 +21,8 @@ Introduce a 'None of the Above' box on all ballot papers to formally and positiv
 
 Introduce voting by proportional representation using the Single Transferable Vote (STV) method in all General and Local Elections.
 
+Introduce new constituencies for British citizens living abroad. 
+
 Investigate the feasibility of electronic voting at all elections, with a view to increasing accessibility and turnout.
 
 Reduce the age of voting at General, Scottish, and European Elections (ie to legislative bodies) and all national and local referenda to those aged 16 years and above.


### PR DESCRIPTION
Currently British citizens who move abroad still vote in Parliamentary elections in the constituency in which they were last registered, even though they often have no remaining ties to that location. Instead, introduce one or more overseas constituencies whose MP(s) specifically represent the people who now live there, similarly to the [French system](https://en.wikipedia.org/wiki/Constituencies_for_French_residents_overseas). This is even more important in the UK where there is a much closer tie between an MP and their constituents.