### PR TITLE
An open registery of land ownership

### DIFF
--- a/manifesto/economy.md
+++ b/manifesto/economy.md
@@ -71,3 +71,9 @@ We will instruct HM Treasury to produce a roadmap for the future of currency and
 The central bank will be required to consider the reduction of inequality (as measured by the GINI coefficient) when formulating monetary policy to balance its existing remit of maintaining price stability and inflation at 2%. 
 
 [^1]: [Stop Secret Contracts](http://stopsecretcontracts.org/)
+
+## Land Ownership
+
+Follow recommendations regarding transparency in the [Lyons Housing Review] (http://www.yourbritain.org.uk/uploads/editor/files/The_Lyons_Housing_Review_2.pdf) - "To ensure greater transparency in the land market, the Land Registry should open up land ownership
+information to the public in a similar manner as the property price paid data set and make it a legal
+requirement to register land option agreements, transactions and prices."


### PR DESCRIPTION
www.yourbritain.org.uk/uploads/editor/files/The_Lyons_Housing_Review_2.pdf - "The Land Registry records the ownership of land and property and has registered 82% of the land in England and Wales with more than 23.5 million titles. However, as evidence to the review highlighted, there is limited public access to this information and no requirement to register land options."

"Greater transparency about ownership, options and transactions would deliver a number of important
benefits that would result in better operation of the land market. "

Let's open this up. Hopefully this will prevent land grabs of common land, and discourage supermarkets buying bits of land just to prevent competition.
