### PR TITLE
Maintain 0.7% GNI commitment to Overseas Development Aid

### DIFF
--- a/manifesto/foreign_policy.md
+++ b/manifesto/foreign_policy.md
@@ -12,7 +12,11 @@ What policies should we adopt in our relations with other countries?
 
 We believe that a clear view of the role that the UN, EU, NATO and other international bodies play in reducing the likelihood of war should be clearly and unambiguosly communicated to the electorate. 
 
-The UK should also use it's membership of such bodies to influence them to reinforce this role and use this peaceful approach whenever possible to avoid conflict.
+The UK should also use its membership of such bodies to influence them to reinforce this role and use this peaceful approach whenever possible to avoid conflict.
+
+## Foreign Aid
+
+We will maintain the UK's committment to the [UN Millennium Project agreement](http://www.unmillenniumproject.org/press/07.htm) of allocating 0.7% of Gross National Income (GNI) to Overseas Development Assistance. These funds will be kept separate from military spending; any required security, demobilisation, or peacekeeping expenses will be seperately funded, from Defence budgets.
 
 ## European Union
 


### PR DESCRIPTION
We should maintain the existing UN Millennium Project commitment of allocating 0.7% of Gross National Income to Overseas Development Aid (http://www.unmillenniumproject.org/press/07.htm), but also ensure that this funding is strictly reserved for those goals, not diverted to military purposes (see http://www.bbc.co.uk/news/uk-politics-21528464 and 
http://www.theguardian.com/politics/2013/feb/21/david-cameron-aid-military)