### PR TITLE
Removal of party politics from Town Councils

### DIFF
--- a/manifesto/local_government.md
+++ b/manifesto/local_government.md
@@ -14,4 +14,8 @@ Publish full minutes (or transcripts if available), audio recordings, and voting
 
 ## Waste and Environment
 
-The Localism Act 2011 repealed powers under The Climate Change Act 2008 which gave councils the ability to charge fine or introduce tariffs regarding household waste. Local authorities are primarily responsible for waste collection and recycling. Consequnetly, local government should have the power to issue financial discencintives (and/or incentives) to encourage recycling and effective waste collection.
+The Localism Act 2011 repealed powers under The Climate Change Act 2008 which gave councils the ability to charge fine or introduce tariffs regarding household waste. Local authorities are primarily responsible for waste collection and recycling. Consequently, local government should have the power to issue financial disincentives (and/or incentives) to encourage recycling and effective waste collection.
+
+## Removing Party Politics from Town Council
+
+Town Councils, which are effectively Parish Councils in all but name, have one distinct difference in that Councillors on Town Councils stand for political parties, whereas all Parish Councillors are not aligned. As Peter MacFayden notes in his book [Flatpack Democracy](http://www.flatpackdemocracy.co.uk/ "Flatpack Democracy"), "at local levels of representation, party politics as practiced by the current political parties are an irrelevant and corrosive diversion." We advocate the removal of party politics from Town Councils in the same way they are removed from Parish Councils.


### PR DESCRIPTION
Most of the entire point of Flatpack Democracy is that local government is outdated and we need movements such as Independents for Frome to inject some life into it. Most of the cause of this is the "irrelevant and corrosive diversion" that is party politics at local level. Creates unnecessary groupings and tribal conflicts rather than helps to get the best for the place the Town Council represents.