### PR TITLE
Oppose gatwick expansion in Horsham manifesto

### DIFF
--- a/manifesto/constituencies/horsham.md
+++ b/manifesto/constituencies/horsham.md
@@ -4,3 +4,8 @@ title: Horsham
 * table of contents 
 {:toc}
 
+## Gatwick Expansion
+
+We are [opposed to expansion of all air travel](/manifesto/transport.html#end-uk-airport-expansion)
+until it can become carbon neutral. This naturally means we are opposed to the 
+expansion of Gatwick airport in particular.


### PR DESCRIPTION
Because we oppose the expansion of air travel until it can become carbon neutral, it makes sense to oppose Gatwick expansion for the same reasons.