### PR TITLE
Repatriation of the Chagossians and revocation of the Chagos MPA 

### DIFF
--- a/manifesto/foreign_policy.md
+++ b/manifesto/foreign_policy.md
@@ -1,18 +1,18 @@
 ---
 title: Foreign Policy
-layout: policy
-published: true
 ---
 * table of contents
 {:toc}
-
-What policies should we adopt in our relations with other countries?
 
 ## Internationalist Stance
 
 We believe that a clear view of the role that the UN, EU, NATO and other international bodies play in reducing the likelihood of war should be clearly and unambiguosly communicated to the electorate. 
 
-The UK should also use it's membership of such bodies to influence them to reinforce this role and use this peaceful approach whenever possible to avoid conflict.
+The UK should also use its membership of such bodies to influence them to reinforce this role and use this peaceful approach whenever possible to avoid conflict.
+
+## Foreign Aid
+
+We will maintain the UK's committment to the [UN Millennium Project agreement](http://www.unmillenniumproject.org/press/07.htm) of allocating 0.7% of Gross National Income (GNI) to Overseas Development Assistance. These funds will be kept separate from military spending; any required security, demobilisation, or peacekeeping expenses will be seperately funded, from Defence budgets.
 
 ## European Union
 
@@ -51,5 +51,15 @@ Resist the adoption of international treaties that could allow unelected institu
 ## Recognition of Palestine
 
 The UK should join many other countries around the world, as well as the UN, and officially recognise Palestine as a sovereign state. This is in line with our existing national preference for a two-state solution to the Israel/Palestine conflict in accordance with international law.
+
+## Use our financial status for ethical ends
+
+We should use our significant financial position within the global economy to help us achieve our ethical foreign policy goals. We should impose financial and trade restrictions against states who pursue aggressive or expansionist policies against their neighbours, or anti-democratic or oppressive policies against their own citizens.
+
+## Repatriation of the Chagossians to the British Indian Ocean Territory
+
+The UK should repatriate fully the natives of the Chagos Archipelagos that were evicted illegally by the British government between 1967 and 1973. All descendants of those originally evicted should be given the option to return. A referendum should then be held from those that choose to return to decide what to do with Naval Support Facility Diego Garcia which is currently based on the islands. 
+
+The UK should revoke the Chagos Marine Protected Area as it was founded under the auspices of a legitimate environmental project, when it was later revealed to be a plot by the Americans to keep the Chagossians off the islands, and it was also declared illegal on 18 March 2015 by the UN's Permanent Court of Arbitration.
 
 [^1]: [Investor-state dispute settlement (ISDS) and the Transatlantic Trade and Investment Partnership (TTIP) - Commons Library Standard Note](http://www.parliament.uk/business/publications/research/briefing-papers/SN06777/investorstate-dispute-settlement-isds-and-the-transatlantic-trade-and-investment-partnership-ttip)


### PR DESCRIPTION
A big issue for hundreds of people. Basically, the UK illegally expelled the natives of the island to make way for the US naval base Diego Garcia. Expelled natives fought several court battles in the 2000s, eventually losing in the House of Lords 3-2. Case has since been taken to ECHR, who said they didn't have the jurisdiction, and a similar case between Mauritius and UK is being fought in the Permanent Court of Arbitration. Also, it is likely Diego Garcia has been used as a secondary torture base by the CIA and for terrorist rendition flights.

Oddly, one of the main champions of this cause is John Prescott, who has used his opinion column in The Mirror to write about it.

Further Reading

http://www.theguardian.com/world/chagos-islands
http://www.chagossupport.org.uk/
https://www.youtube.com/watch?v=0zhGvId4fcc
http://www.instituteofopinion.com/2015/02/the-uks-indian-ocean-territory-in-the-spotlight-again/
http://www.mirror.co.uk/news/uk-news/after-shameful-exile-its-time-5165979
http://www.mirror.co.uk/news/uk-news/people-chagos-islands-return-paradise-4847374