### PR TITLE
Transport: allocate road space to bus lanes

### DIFF
--- a/manifesto/transport.md
+++ b/manifesto/transport.md
@@ -52,3 +52,7 @@ Develop a long-term plan for complete electrification of the national rail netwo
 Investigate feasibility of building a high speed rail network that connects our ten largest cities (and Cardiff also) to the European high speed network via HS1.
 
 Examine which areas of the United Kingdom were most detrimentally affected by the changes in the [Beeching Reports](https://en.wikipedia.org/wiki/Beeching_cuts), and whether it would be economically feasible to bring back any formerly established railways.
+
+## Bus
+
+Promote efficient use of road space in towns and cities by allocating road space to bus lanes, encouraging the creation of a network of frequent bus routes.


### PR DESCRIPTION
My suggestion is to encourage frequent service where there is appropriately dense land use ("towns and cities") as this will reduce traffic and congestion. "Allocating road space" will mean taking space away from other traffic. Making bus journeys faster improves both travel time and time waiting for the next bus (it's a double benefit).

Congested roads exist because there's not enough space for all the vehicles (this is true, even with electric cars). I'd like to reward people who are reducing traffic by using public transport.

I think this policy is consistent with other policies in this section, which encourage a shift to less-polluting modes of transport.

I'm influenced by [Human Transit](http://www.humantransit.org/2015/07/mega-explainer-the-ridership-recipe.html) in this suggestion.