### PR TITLE
Added a new section

### DIFF
--- a/culture.md
+++ b/culture.md
@@ -17,3 +17,7 @@ Immediately reduce the term of copyright from '70 years from the end of the cale
 Encourage the Advertising Standards Authority to tighten regulations around the use of pseudo-scientific language and terminology for the promotion of cosmetic, toiletry, food or other products, without sufficient evidence.
 
 [^1]: [Can we have our freedom to joke now please?](https://www.openrightsgroup.org/campaigns/modernise-copyright) - Open Rights Group
+
+## Media Retractions
+
+Media outlet retractions should mirror the original article. This covers font size, word count, page space and positioning within the document. If a media outlet does not follow this it will receive a fine from OfCom.

--- a/culture.md
+++ b/culture.md
@@ -20,4 +20,4 @@ Encourage the Advertising Standards Authority to tighten regulations around the 
 
 ## Media Retractions
 
-Media outlet retractions should mirror the original article. This covers font size, word count, page space and positioning within the document. If a media outlet does not follow this it will receive a fine from OfCom.
+Media outlet retractions should mirror the original article. This covers font size, word count, page space and positioning within the document. If a media outlet does not follow this it will receive a fine from Independent Press Standards Organisation (IPSO).


### PR DESCRIPTION
Media retractions are rare. Mostly an outlet will just retrospectively delete the article from their back catalog. This isn't acceptable as it subverts the public dialogue. This website is good for tracking the Sun alone but all outlets are guilty of this http://the-sun-lies.blogspot.co.uk/2009/01/echo-chamber.html. 

It was asked that the request stay small so I've shy'd away from a further punishment for a number of consecutive retractions but I would like to introduce this too you at a later point. I would suggest 3 retractions in 3 months requires a fine and a headline, dictated by a regulator of the retractions, this would take the prominent position in the News Outlet.

I would also suggest that we consider enforcing fines for article deletions, instead of retractions. 

Be good journalists, if you fail, retract the article. If you fail frequently, its by choice or you need a new profession, either way, stop it! :)