### PR TITLE
Addition to Housing - Housing Associations

### DIFF
--- a/housing.md
+++ b/housing.md
@@ -29,3 +29,7 @@ Replace council tax with a Land Value Tax as detailed in Economy 5.1.
 ## Housing Benefit
 
 Repeal the size criteria for housing benefit (commonly known as the "Bedroom Tax"), which punishes housing benefit claimants for having spare rooms when in many cases smaller properties are not available for them to move into.
+
+## Housing Association
+
+If a privately run housing association seeks to sell properties because they are unprofitable, we believe that the local authority should be able to buy the houses at a preferential rate. The local authority would then use these properties as council houses. We believe that this will help ease the waiting time for council houses, providing security for many families across the country.


### PR DESCRIPTION
A note about the sale of unprofitable housing from privately run housing associations. These properties are generally purchased by developers with either the land or property recommissioned (gentrified). It would be more sensible if the property was given over to the Local Authority and placed on the council housing list.

I know people on those lists and its a deeply unsettling life. A modern (pre-modern) tragedy really. :(