### PR TITLE
Remove heading at start of education page

### DIFF
--- a/education.md
+++ b/education.md
@@ -5,13 +5,7 @@ title: Education
 * table of contents
 {:toc}
 
-## Principles of Education
-
-We believe that education is the keystone that makes all other longer-term strategic policies possible: improving industry and employment; the arts; scientific discovery and research; improving the overall health and well-being of society; and reducing crime. It is the policy area that can justify significant investment in recognition of the dividend that all other areas of public spending will receive 10-15 years hence.
-
-Subsequently we recognise that education is about more than simply equipping the future workforce with relevant vocational and professional skills, but about creating a future society that is healthy, wise, and wealthy in all respects.
-
-We believe that learning is life long and should be encouraged in all elements of life, personal and professional.
+We believe that education is the keystone that makes all other longer-term strategic policies possible: improving industry and employment; the arts; scientific discovery and research; improving the overall health and well-being of society; and reducing crime. It is the policy area that can justify significant investment in recognition of the dividend that all other areas of public spending will receive 10-15 years hence. We also recognise that education is about more than simply equipping the future workforce with relevant vocational and professional skills, but about creating a future society that is healthy, wise, and wealthy in all respects. We believe that learning is life long and should be encouraged in all aspects of life, personal and professional.
 
 ## Funding
 


### PR DESCRIPTION
So that the first sections acts as the lead paragraph, setting the tone for the rest.