### PR TITLE
Refine house of lords policy a little

### DIFF
--- a/democracy.md
+++ b/democracy.md
@@ -58,21 +58,21 @@ In the case that a local area is unable to deal with any issue effectively, ther
 
 ## House of Lords Reform
 
-We believe in replacing the House of Lords with a more representative chamber. However, there are immediate reforms required and so while we will work to replace the House of Lords, we will apply incremental reform to the Lords before hand to improve our democracy in the meantime. These reforms are outline below, in the order in which we'll hope to implement them.
+We believe in replacing the House of Lords with a more representative chamber. However, there are immediate reforms required and so while we will work to replace the House of Lords, we will apply incremental reform to the Lords before hand to improve our democracy in the meantime. These reforms are outlined below, in the order in which we'll hope to implement them.
 
 ### Cease all new appointments
 
-Upon entering Government we will immediately end all new appointments to the House of Lords, swiftly ending the undemocratic procedure.
+Upon entering Government we will immediately end all new appointments to the House of Lords, swiftly ending the undemocratic selection procedure.
 
-### Cut membership to 650
+### Cut membership to equal the Commons
 
-The "upper house" - as it is known - should not contain more Lords than MPs. We will place a cap on Lords of 650, and seek to remove those Lords with the lowest attendance in order to drop the current levels down to match the House of Commons.
+The House of Lords should not contain more Lords than MPs. We will place a cap on the Lords equal to the number of MPs at any one time, and remove those Lords with the lowest attendance in order to drop the current levels to match the House of Commons.
 
 ### House of Citizens
 
-The House of Lords will be replaced with a chamber made up of randomly-selected citizens tasked with reviewing and amending legislation created by the House of Commons.
+In time, the House of Lords will be replaced with a chamber made up of randomly-selected citizens tasked with reviewing and amending legislation created by the House of Commons.
 
-Citizens are selected from the electoral roll and serve a single fixed-length term. A subset of the chamber is changed each year. Leave from work is legally protected, and help back to work included in the cost.
+Citizens are selected from the electoral roll and serve a single fixed-length term. A subset of the chamber is changed each year. Leave from work is legally protected, and help back to work included in the cost. Citizens serving in the House of Citizens will be paid equally to MPs serving in the Commons.
 
 ## MPs pay and expenses
 


### PR DESCRIPTION
Some spelling and minor wording fixes, but two policy enhancements:

1. Change 650 number to be "equal to the commons" instead.

2. State that House of Citizens members will be paid the same as Commons MPs.