### PR TITLE
Fix footnotes in print versions

### DIFF
--- a/communications.md
+++ b/communications.md
@@ -14,7 +14,7 @@ In a connected future, Internet access is a basic right. Moving the process of g
 
 Require all UK Internet Service Providers to provide IPv6 connections to home and business users by 2020[^ipv6].
 
-[^ipv6]: [Ofcom in denial over UK IPv6 failure](http://www.emilytaylor.eu/ofcom-in-denial-ipv6/)
+[^ipv6]: *"Ofcom in denial over UK IPv6 failure"*, Oxford Information Labs, December 11, 2014: [https://oxil.uk/ofcom-in-denial-over-uk-ipv6-failure/](https://oxil.uk/ofcom-in-denial-over-uk-ipv6-failure/)
 
 ## Surveillance
 

--- a/crime.md
+++ b/crime.md
@@ -41,7 +41,7 @@ With a comprehensive strategy allowing for strategies at all levels and areas of
 
 All frontline Police officers will be equipped with personal cameras for the potential reduction in complaints and violence[^police-cameras]
 
-[^police-cameras]: [Wearing a Badge, and a Video Camera](http://mobile.nytimes.com/2013/04/07/business/wearable-video-cameras-for-police-officers.html?_r=0) - New York Times
+[^police-cameras]: *"Wearing a Badge, and a Video Camera"*:, New York Times, April 6, 2013: [http://www.nytimes.com/2013/04/07/business/wearable-video-cameras-for-police-officers.html](http://www.nytimes.com/2013/04/07/business/wearable-video-cameras-for-police-officers.html)
 
 ### Independent Police Complaints Commission
 

--- a/crime.md
+++ b/crime.md
@@ -51,9 +51,7 @@ Expand the role of the Independent Police Complaints Commission (IPCC) to includ
 
 A single, secular oath will replace the current options for witnesses in all court proceedings.
 
-Specifically outlaw religious courts, such as Sharia Law courts, by banning their operations within and outside the legal system. Support the One Law for All campaign.[^onelaw]
-
-[^onelaw]: [One Law for All](http://www.onelawforall.org.uk/)
+Specifically outlaw religious courts, such as Sharia Law courts, by banning their operations within and outside the legal system. Support the [One Law for All](http://www.onelawforall.org.uk/) campaign.
 
 A review will be carried out into the composition of juries, especially for complex trials.
 

--- a/culture.md
+++ b/culture.md
@@ -8,7 +8,7 @@ Reform copyright law to allow use for parody[^org-copyright].
 
 Reform copyright law to allow format-shifting of purchased media (for example, from CD to MP3)[^org-copyright].
 
-[^org-copyright]: [Can we have our freedom to joke now please?](https://www.openrightsgroup.org/campaigns/modernise-copyright) - Open Rights Group
+[^org-copyright]: *"Can we have our freedom to joke now please?"*, Open Rights Group: [https://www.openrightsgroup.org/campaigns/modernise-copyright](https://www.openrightsgroup.org/campaigns/modernise-copyright)
 
 Immediately reduce the term of copyright from "70 years from the end of the calendar year of the author's death" to two 40 year terms, with a renewal necessary after the first 40 years. Make the necessary preparations for a general case within the World Trade Organization's Dispute Settlement Body, regarding UK conformity with the [Berne Convention](https://en.wikipedia.org/wiki/Berne_Convention_for_the_Protection_of_Literary_and_Artistic_Works)).
 

--- a/democracy.md
+++ b/democracy.md
@@ -8,7 +8,7 @@ We believe that the UK should be a truly democratic country, where the state is 
 
 The British constitution should be collected into a single written document that defines and regulates the powers of the British government, and the rights and duties of its citizens[^constitution].
 
-[^constitution]: [Do we need a written constitution?](https://web.archive.org/web/20140730032323/http://www.consoc.org.uk/other-content/about-us/discover-the-facts/do-we-need-a-written-constitution/) - The Constitution Society
+[^constitution]: *"Do we need a written constitution?"*, The Constitution Society: [https://web.archive.org/web/20140730032323/http://www.consoc.org.uk/other-content/about-us/discover-the-facts/do-we-need-a-written-constitution/](https://web.archive.org/web/20140730032323/http://www.consoc.org.uk/other-content/about-us/discover-the-facts/do-we-need-a-written-constitution/)
 
 The constitution could either be created by a citizens' panel, with approval and adoption subject to a referendum, or created as a "blank slate", with every addition done as an amendment by Parliament with a super-majority vote (e.g. 75% in favour).
 
@@ -31,7 +31,7 @@ Require all MPs to retrospectively publish their diaries on a daily basis as ope
 
 We want to establish a single, comprehensive and mandatory statutory register of political lobbyists. This will replace the four voluntary options currently available to lobbyists. This register must contain all paid lobbyists and it must give us meaningful information on what lobbyists are up to, including who is lobbying for who, which agency of government are being lobbied, and broadly what lobbyists are aiming to influence.[^lobbying]
 
-[^lobbying]: [Alliance for Lobbying Transparency](http://www.lobbyingtransparency.org/#home)
+[^lobbying]: As suggested by the Alliance for Lobbying Transparency: [http://www.lobbyingtransparency.org/](http://www.lobbyingtransparency.org/)
 
 ## Devolution
 
@@ -89,7 +89,7 @@ British subjects shall pay no fee to enter parliamentary grounds.
 
 Fully include of the monarchy within the Freedom of Information Act (FOIA), so that the royal household is legally obliged to respond to information requests[^royal-secrecy].
 
-[^royal-secrecy]: [Campaign against royal secrecy](http://republic.org.uk/what-we-do/current-campaigns/campaign-against-royal-secrecy)
+[^royal-secrecy]: *"Campaign against royal secrecy"*, Republic: [https://www.republic.org.uk/what-we-do/current-campaigns/campaign-against-royal-secrecy](http://republic.org.uk/what-we-do/current-campaigns/campaign-against-royal-secrecy)
 
 Repeal existing exemptions from the FOIA that allow communications between other government bodies and the members of the royal family to be kept secret.
 

--- a/economy.md
+++ b/economy.md
@@ -62,10 +62,9 @@ Improve rental rights, such that residential tenants cannot be evicted if they a
 
 Adopt Land Value Taxation (LVT)[^lvt], a charge on the rental value of land not including any improvements made on the site (such as buildings, drainage and services). Valuation to be based on market evidence, in accordance with the optimum use of the land within the planning regulations and updated regularly (at least every 2 years)[^lvt-england][^lvt-scotland]. LVT would replace Council Tax,  Uniform Business Rates, and Stamp Duty. There will be two rates of Land Value Tax - a national rate and a local rate. The national rate will be decoded after consultation and research. The local rate will be set at the discretion of each local authority. Public open space, public transport infrastructure and open water will all be exempt from LVT. Local and national government property will not be exempt, to encourage the efficient allocation of publicly owned assets.
 
-[^lvt]: [Land Value Taxation Campaign - What is LVT?](http://www.landvaluetax.org/what-is-lvt/)
-[^lvt-england]: [A Land Value Tax for England](http://www.andywightman.com/docs/LVT_england_final.pdf)
-[^lvt-scotland]: [A Land Value Tax for Scotland](http://www.andywightman.com/docs/LVTREPORT.pdf)
-
+[^lvt]: *"What is LVT?"*, Land Value Taxation Campaign: [http://www.landvaluetax.org/what-is-lvt/](http://www.landvaluetax.org/what-is-lvt/)
+[^lvt-england]: *"A Land Value Tax for England"*, Andy Wightman, March 2013: [http://www.andywightman.com/docs/LVT_england_final.pdf](http://www.andywightman.com/docs/LVT_england_final.pdf)
+[^lvt-scotland]: *"A Land Value Tax for Scotland"*, Andy Wightman, October 2010: [http://www.andywightman.com/docs/LVTREPORT.pdf](http://www.andywightman.com/docs/LVTREPORT.pdf)
 
 ## Business
 
@@ -83,7 +82,7 @@ Ensure worker-owned cooperatives and mutuals are given priority with all governm
 
 All private companies who receive public money must be subject to the same transparency requirements as governments when it comes to the goods and services they deliver[^secret-contracts].
 
-[^secret-contracts]: [Stop Secret Contracts](http://stopsecretcontracts.org/)
+[^secret-contracts]: *"Stop Secret Contracts"*: [http://stopsecretcontracts.org/](http://stopsecretcontracts.org/)
 
 ## Public Sector
 

--- a/education.md
+++ b/education.md
@@ -14,9 +14,9 @@ Education should be freely available to all to first degree level or equivalent.
 
 50% of the British public identify as having no religion, and this number is growing[^bsa-religion] but over half of all state funded schools have a religious character[^faith-schools], including over 4,500 Church of England schools. It has been demonstrated that faith schools are religiously selective, excluding those of other or no faith[^fair-admissions].
 
-[^bsa-religion]: [British Social Attitudes Survey](http://ir2.flife.de/data/natcen-social-research/igb_html/pdf/chapters/BSA28_12Religion.pdf) (pdf)
 [^faith-schools]: [Maintained Faith Schools, Department for Education](https://www.gov.uk/government/publications/maintained-faith-schools/maintained-faith-schools)
 [^fair-admissions]: [Fair Admissions Campaign](http://fairadmissions.org.uk/groundbreaking-new-research-maps-the-segregating-impact-of-faith-school-admissions/)
+[^bsa-religion]: *"British Social Attitudes 28: Religion"*, NatCen, 2012:  [http://www.bsa.natcen.ac.uk/latest-report/british-social-attitudes-28/religion.aspx](http://www.bsa.natcen.ac.uk/latest-report/british-social-attitudes-28/religion.aspx)
 
 Therefore, we will mandate that all state-funded schools be secular in nature.
 

--- a/education.md
+++ b/education.md
@@ -14,9 +14,9 @@ Education should be freely available to all to first degree level or equivalent.
 
 50% of the British public identify as having no religion, and this number is growing[^bsa-religion] but over half of all state funded schools have a religious character[^faith-schools], including over 4,500 Church of England schools. It has been demonstrated that faith schools are religiously selective, excluding those of other or no faith[^fair-admissions].
 
-[^faith-schools]: [Maintained Faith Schools, Department for Education](https://www.gov.uk/government/publications/maintained-faith-schools/maintained-faith-schools)
-[^fair-admissions]: [Fair Admissions Campaign](http://fairadmissions.org.uk/groundbreaking-new-research-maps-the-segregating-impact-of-faith-school-admissions/)
 [^bsa-religion]: *"British Social Attitudes 28: Religion"*, NatCen, 2012:  [http://www.bsa.natcen.ac.uk/latest-report/british-social-attitudes-28/religion.aspx](http://www.bsa.natcen.ac.uk/latest-report/british-social-attitudes-28/religion.aspx)
+[^faith-schools]: *"Maintained Faith Schools"*, Department for Education, July 20, 2010: [https://www.gov.uk/government/publications/maintained-faith-schools/maintained-faith-schools](https://www.gov.uk/government/publications/maintained-faith-schools/maintained-faith-schools)
+[^fair-admissions]: *"Groundbreaking new research maps the segregating impact of faith school admissions"*, Fair Admissions Campaign, December 3, 2013: [http://fairadmissions.org.uk/groundbreaking-new-research-maps-the-segregating-impact-of-faith-school-admissions/](http://fairadmissions.org.uk/groundbreaking-new-research-maps-the-segregating-impact-of-faith-school-admissions/)
 
 Therefore, we will mandate that all state-funded schools be secular in nature.
 
@@ -46,6 +46,6 @@ Funding to the Open University, and other distance learning courses will be incr
 
 We will remove the guidelines[^teachers-and-terrorism] that force teachers to act as counter-terrorism officers and that stifle free speech within the learning environment. 
 
-[^teachers-and-terrorism]: [Teachers forced to act as 'front-line storm troopers' to spy on pupils under guidelines aimed at combating terrorism](http://www.independent.co.uk/news/education/education-news/teachers-forced-to-act-as-frontline-storm-troopers-to-spy-on-pupils-under-guidelines-aimed-at-combating-terrorism-10158043.html)
+[^teachers-and-terrorism]: *"Teachers forced to act as 'front-line storm troopers' to spy on pupils under guidelines aimed at combating terrorism"*, The Independent, April 6, 2015:  [http://www.independent.co.uk/news/education/education-news/teachers-forced-to-act-as-frontline-storm-troopers-to-spy-on-pupils-under-guidelines-aimed-at-combating-terrorism-10158043.html](http://www.independent.co.uk/news/education/education-news/teachers-forced-to-act-as-frontline-storm-troopers-to-spy-on-pupils-under-guidelines-aimed-at-combating-terrorism-10158043.html)
 
 We will include fiscal education into the national curriculum. This will include personal finances, understanding and paying taxes, understanding loans and debt, and relating fiscal choices to the state of the greater economy.  

--- a/elections.md
+++ b/elections.md
@@ -50,4 +50,4 @@ Investigate the feasibility of direct digital democracy - using online tools to 
 
 Investigate methods for deliberative democracy[^rebooting-democracy] - things which increase research and understanding before decision making. Run trials of these for small decisions. Implement proven ones for members of the upper and lower house, and for ministers. 
 
-[^rebooting-democracy]: [Rebooting Democracy: A Citizen's Guide to Reinventing Politics](http://www.amazon.co.uk/Rebooting-Democracy-Citizens-Reinventing-Politics/dp/191019817X) - Manuel Arriaga
+[^rebooting-democracy]: *"Rebooting Democracy: A Citizen's Guide to Reinventing Politics"*, Manuel Arriaga, 2014: [http://www.rebootdemocracy.org/book/](http://www.rebootdemocracy.org/book/)

--- a/foreign_policy.md
+++ b/foreign_policy.md
@@ -65,7 +65,7 @@ We fundamentally believe in self-determination for residents of the British Over
 
 We will conduct a review into the state of democracy and people’s rights on Ascension Island. This review will include the right to abode, cementing the powers of the Ascension Island Council and the right to own property.[^ascension]
 
-[^ascension]: ["US and UK accused of 'squeezing life out of' Ascension Island", *The Guardian*](http://www.theguardian.com/uk-news/2013/sep/11/ascension-island-population-cut-uk-government)
+[^ascension]: *"US and UK accused of 'squeezing life out of' Ascension Island"*, The Guardian, September 11, 2013:  [http://www.theguardian.com/uk-news/2013/sep/11/ascension-island-population-cut-uk-government](http://www.theguardian.com/uk-news/2013/sep/11/ascension-island-population-cut-uk-government)
 
 ### British Indian Ocean Territory
 
@@ -85,10 +85,10 @@ We will commission a report into how best to help Montserrat recover in the long
 
 We will grant British citizenship to the 67 residents of Richmond Village, Akrotiri, Cyprus.[^akrotiri]
 
-[^akrotiri]: ["We're in limbo: the families marooned at a British military base for 16 years", *The Guardian*](http://www.theguardian.com/world/2014/oct/21/refugee-families-marooned-raf-base-cyprus)
+[^akrotiri]: *"We're in limbo: the families marooned at a British military base for 16 years"*, The Guardian, October 21, 2014: [http://www.theguardian.com/world/2014/oct/21/refugee-families-marooned-raf-base-cyprus](http://www.theguardian.com/world/2014/oct/21/refugee-families-marooned-raf-base-cyprus)
 
 ## PKK and Turkey Peace Process
 
 We recognise that the PKK (Kurdistan Workers' Party) has attempted to turn to peaceful means to secure rights for the Kurdish people[^pkk]. We also note the PKK's leadership in resisting the brutality of the ISIS forces in the Middle East. We therefore wish to delist the PKK as a terrorist organisation should it commit itself to disarming in Turkey and re-engaging in the peace process.
 
-[^pkk]: [The Case for Delisting the PKK as a Foreign Terrorist Organization](https://www.lawfareblog.com/case-delisting-pkk-foreign-terrorist-organization)
+[^pkk]: *"The Case for Delisting the PKK as a Foreign Terrorist Organization"*, Lawfare, February 11, 2016: [https://www.lawfareblog.com/case-delisting-pkk-foreign-terrorist-organization](https://www.lawfareblog.com/case-delisting-pkk-foreign-terrorist-organization)

--- a/foreign_policy.md
+++ b/foreign_policy.md
@@ -47,7 +47,7 @@ Whilst it's right that those nations that make the greatest contribution to UN t
 
 Resist the adoption of international treaties that could allow unelected institutions to have a chilling effect on government policy that is in the public interest of UK voters. A current example is the Investor-State Dispute Settlement (ISDS) process in the TTIP treaty currently under negotiation[^isds], which undermines democratic processes and could prevent the government taking action which benefits the UK if it causes potential losses for foreign investors.
 
-[^isds]: [Investor-state dispute settlement (ISDS) and the Transatlantic Trade and Investment Partnership (TTIP) - Commons Library Standard Note](http://www.parliament.uk/business/publications/research/briefing-papers/SN06777/investorstate-dispute-settlement-isds-and-the-transatlantic-trade-and-investment-partnership-ttip)
+[^isds]: *"Investor-state dispute settlement (ISDS) and the Transatlantic Trade and Investment Partnership (TTIP)"*,  Commons Briefing paper SN06777, December 11, 2013: [http://researchbriefings.parliament.uk/ResearchBriefing/Summary/SN06777](http://researchbriefings.parliament.uk/ResearchBriefing/Summary/SN06777)
 
 ## Recognition of Palestine
 

--- a/health.md
+++ b/health.md
@@ -39,7 +39,7 @@ The organ donation wishes of the deceased will not be permitted to be overridden
 
 Alcohol misuse is a serious health issue costing around £21 billion per year[^alcohol-impact], including related crime. Much of this is down to the sale of cheap alcohol products that allow for over-consumption. A Minimum Unit Price (MUP) of 45p will curb dangerous consumption habits whilst having a negligible, if any, impact on responsible drinkers. An estimated economic net benefit in excess of £300m is achievable.
 
-[^alcohol-impact]: [Impact Assessment: A Minimum Unit Price for Alcohol](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/157763/ia-minimum-unit-pricing.pdf)
+[^alcohol-impact]: *"Impact Assessment: A Minimum Unit Price for Alcohol"*, Home Office, Novermber 1 2012:  [https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/157763/ia-minimum-unit-pricing.pdf](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/157763/ia-minimum-unit-pricing.pdf)
 
 Resulting price increases would largely be restricted to off-trade retailers such as supermarkets and off-licenses and so would not have a large negative impact on the licensed pub trade.
 
@@ -48,7 +48,7 @@ Examples:
  * A 3 litre bottle of 4.7% ABV cider can be purchased for as little as £3.99 and contains 14.1 units of alcohol. An MUP of 45p would force this up to at least £8.81 (£6.35 MUP + £1.27 VAT + £1.19 duty).
  * A pint of 4% draught beer can be purchased for around £3.21[^beer-prices] and contains 2.3 units of alcohol. An MUP of 45p would make the minimum legal price £1.65 (£1.35 MUP + £0.21 VAT + £0.09 duty), well below the current price.
 
- [^beer-prices]: [Average prices for pint of beer across UK revealed](http://www.mirror.co.uk/money/personal-finance/average-prices-pint-beer-across-2234409#ixzz2tOXabpqa)
+ [^beer-prices]: *"Average prices for pint of beer across UK revealed"*, Daily Mirror, August 29, 2013: [http://www.mirror.co.uk/money/personal-finance/average-prices-pint-beer-across-2234409](http://www.mirror.co.uk/money/personal-finance/average-prices-pint-beer-across-2234409)
 
 ## Parking Charges
 

--- a/health.md
+++ b/health.md
@@ -44,6 +44,7 @@ Alcohol misuse is a serious health issue costing around £21 billion per year[^a
 Resulting price increases would largely be restricted to off-trade retailers such as supermarkets and off-licenses and so would not have a large negative impact on the licensed pub trade.
 
 Examples:
+
  * A 3 litre bottle of 4.7% ABV cider can be purchased for as little as £3.99 and contains 14.1 units of alcohol. An MUP of 45p would force this up to at least £8.81 (£6.35 MUP + £1.27 VAT + £1.19 duty).
  * A pint of 4% draught beer can be purchased for around £3.21[^beer-prices] and contains 2.3 units of alcohol. An MUP of 45p would make the minimum legal price £1.65 (£1.35 MUP + £0.21 VAT + £0.09 duty), well below the current price.
 

--- a/military.md
+++ b/military.md
@@ -34,4 +34,4 @@ Giving machines the power to decide who lives and dies on the battlefield is an 
 
 We will lead the UN and other international bodies to create an international treaty, similar to the Geneva Convention, banning the development and use of lethal autonomous weapon systems.
 
-+[^killer-robots]: [Campaign to stop killer robots](http://www.stopkillerrobots.org/the-solution/)
++[^killer-robots]: Campaign to stop killer robots: [http://www.stopkillerrobots.org/the-solution/](http://www.stopkillerrobots.org/the-solution/)

--- a/poverty.md
+++ b/poverty.md
@@ -15,7 +15,7 @@ To give the public greater financial security we will;
 
 The Office for Budget Responsibility will be given a new role in accessing and forecasting levels of poverty, while the Social Mobility and Child Poverty Commission will have it's remit extended to the whole of the UK to more effectively hold the government to account[^rowntree-poverty].
 
-[^rowntree-poverty]: [Recommendation from Joseph Rowntree Foundation report, September 2014](http://www.jrf.org.uk/a-uk-without-poverty)
+[^rowntree-poverty]: As recommended by *"A UK without poverty"*, Joseph Rowntree Foundation, September 2014: [http://www.jrf.org.uk/a-uk-without-poverty](http://www.jrf.org.uk/a-uk-without-poverty)
 
 ## Inequality
 

--- a/science.md
+++ b/science.md
@@ -6,7 +6,7 @@ title: Science
 
 The UK should spend at least 0.8% of GDP on scientific research and development[^science-is-vital]. 0.8% is the average amongst the G8 countries, and as of March 2015, the UK spends less than 0.5%[^uk-research-funding], one of the lowest in the G8.
 
-[^science-is-vital]: [Science is Vital](http://scienceisvital.org.uk/)
+[^science-is-vital]: As proposed by the Science is Vital campaign: [http://scienceisvital.org.uk/](http://scienceisvital.org.uk/)
 [^uk-research-funding]: *"UK research funding slumps below 0.5% GDP – putting us last in the G8"*, The Guardian, March 13, 2015: [https://www.theguardian.com/science/occams-corner/2015/mar/13/science-vital-uk-spending-research-gdp](https://www.theguardian.com/science/occams-corner/2015/mar/13/science-vital-uk-spending-research-gdp)
 
 Implement a favourable tax regime for private sector investment in scientific and technical research

--- a/science.md
+++ b/science.md
@@ -4,10 +4,10 @@ title: Science
 
 ## Science Funding
 
-The UK should spend at least 0.8% of GDP on scientific research and development[^science-is-vital]. 0.8% is the average amongst the G8 countries, and as of March 2015, the UK spends less than 0.5%[^siv-tell-them], one of the lowest in the G8.
+The UK should spend at least 0.8% of GDP on scientific research and development[^science-is-vital]. 0.8% is the average amongst the G8 countries, and as of March 2015, the UK spends less than 0.5%[^uk-research-funding], one of the lowest in the G8.
 
 [^science-is-vital]: [Science is Vital](http://scienceisvital.org.uk/)
-[^siv-tell-them]: [Tell Them Science is Vital](http://scienceisvital.org.uk/tell-them-science-is-vital/)
+[^uk-research-funding]: *"UK research funding slumps below 0.5% GDP – putting us last in the G8"*, The Guardian, March 13, 2015: [https://www.theguardian.com/science/occams-corner/2015/mar/13/science-vital-uk-spending-research-gdp](https://www.theguardian.com/science/occams-corner/2015/mar/13/science-vital-uk-spending-research-gdp)
 
 Implement a favourable tax regime for private sector investment in scientific and technical research
 

--- a/society.md
+++ b/society.md
@@ -8,7 +8,7 @@ With 50-62% of the British public having no religion[^yougov-religion], includin
 
 [^bsa-religion]: *"British Social Attitudes 28: Religion"*, NatCen, 2012:  [http://www.bsa.natcen.ac.uk/latest-report/british-social-attitudes-28/religion.aspx](http://www.bsa.natcen.ac.uk/latest-report/british-social-attitudes-28/religion.aspx)
 
-[^yougov-religion]: *"Easter Religion and Other News", British Religion in Numbers, April 5, 2015: [http://www.brin.ac.uk/2015/easter-religion-and-other-news/](http://www.brin.ac.uk/2015/easter-religion-and-other-news/)
+[^yougov-religion]: *"Easter Religion and Other News"*, British Religion in Numbers, April 5, 2015: [http://www.brin.ac.uk/2015/easter-religion-and-other-news/](http://www.brin.ac.uk/2015/easter-religion-and-other-news/)
 
 
 Human rights are paramount, because we are all human but not all religious. No-one should be restricted from practising their religious beliefs unless those beliefs infringe on the human rights of others. Equally, the non-religious or those of other religions, should be free of interference from religions. So we will enshrine in law two principles;

--- a/society.md
+++ b/society.md
@@ -6,9 +6,9 @@ title: Society
 
 With 50-62% of the British public having no religion[^yougov-religion], including 64% of those aged 18-24[^bsa-religion], Britain is no longer a Christian country and so its official status as such will be removed. Britain will become a secular nation under a Secularism Act.
 
-[^bsa-religion]: [British Social Attitudes Survey](http://ir2.flife.de/data/natcen-social-research/igb_html/pdf/chapters/BSA28_12Religion.pdf) (pdf)
+[^bsa-religion]: *"British Social Attitudes 28: Religion"*, NatCen, 2012:  [http://www.bsa.natcen.ac.uk/latest-report/british-social-attitudes-28/religion.aspx](http://www.bsa.natcen.ac.uk/latest-report/british-social-attitudes-28/religion.aspx)
 
-[^yougov-religion]: [YouGov poll](http://www.secularism.org.uk/news/2015/04/as-cameron-says-uk-still-a-christian-country-62-percent-tell-yougov-they-are-not-religious)
+[^yougov-religion]: *"Easter Religion and Other News", British Religion in Numbers, April 5, 2015: [http://www.brin.ac.uk/2015/easter-religion-and-other-news/](http://www.brin.ac.uk/2015/easter-religion-and-other-news/)
 
 
 Human rights are paramount, because we are all human but not all religious. No-one should be restricted from practising their religious beliefs unless those beliefs infringe on the human rights of others. Equally, the non-religious or those of other religions, should be free of interference from religions. So we will enshrine in law two principles;


### PR DESCRIPTION
In print, URLs in footnotes don't get expanded. I've tweaked the structure of footnotes that are only links to show the URL explicitly, so that in print the reference can all be seen properly.

I've also updated some footnotes to point to more-primary sources, and included dates and sources where possible.

No policy changes.