### PR TITLE
Adjustment to manifesto introduction

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ We believe that government should be:
 
 We believe that individuals should:
 
-* Be treated equally by the law, regardless of gender identity, sex, romantic orientation, sexual orientation, ethnicity, race, perceived ethnicity and/or race, age, religious and/or spiritual belief, occupation or disability.
+* Be treated equally by the law, regardless of gender identity, sex, romantic orientation, sexual orientation, ethnicity, race, perceived ethnicity and/or race, age, religious and/or spiritual belief, occupation (current or previous), status of union membership (including the type of union and what union), marital status, or disability.
 * Be free to act in any manner that does not harm another individual, and does not infringe upon the rights of other individuals.
 * Enjoy a fundamental right to privacy from the state or their agents.
 

--- a/index.md
+++ b/index.md
@@ -12,10 +12,10 @@ We believe that government should be:
 * Ethical: dedicated to creating a sustainable society and economy with progressive moral values.
 * Bottom-up: People should be telling the government what they want from a local level, rather than being told from the top. 
 
-We believe that individuals should be:
+We believe that individuals should:
 
-* Treated equally by the law and society, regardless of gender, sexuality, ethnicity, age, belief or disability.
-* Free to act in any manner that does not harm another individual, and does not infringe upon the rights of other individuals.
+* Be treated equally by the law, regardless of gender identity, sex, romantic orientation, sexual orientation, ethnicity, race, perceived ethnicity and/or race, age, religious and/or spiritual belief, occupation or disability.
+* Be free to act in any manner that does not harm another individual, and does not infringe upon the rights of other individuals.
 * Enjoy a fundamental right to privacy from the state or their agents.
 
 In short, we wish to ensure government remains open and transparent, whilst individuals retain liberty and privacy.


### PR DESCRIPTION
Added a few more categories that shouldn't be discriminated against, removed society, as adjusting society could be interpreted as a clamp down on freedom of speech, and changed the wording to make it flow properly both as a list and read as a continuous sentence.