### PR TITLE
Replace Vehicle Excise Duty and Fuel Duty 2

### DIFF
--- a/transport.md
+++ b/transport.md
@@ -2,17 +2,21 @@
 title: Transport
 ---
 
-## Removal of Fossil Fuels
+## Replace Vehicle Excise Duty and Fuel Duty
 
-No new fossil-fuel powered vehicles may be sold in the UK after 2029.
+'Vehicle Excise Duty' and 'Fuel Duty' will be replaced with an 'Emissions Tax' and 'Road Strengthening Tax' respectively.
 
-## Scrap Vehicle Excise Duty
+These changes to the titles in the tax system are meant to reflect the given purpose of the tax, making them more understandable to the public; providing greater transparency to them about what they are being taxed for, and some degree of protection against double-taxation also.
 
-As Vehicle Excise Duty is associated with vehicle emissions, it seems fairer to tax
-the fuel directly. VED should be scrapped, and fuel duty increased to cover the reduction
-in income. Overall, the tax levied should be lower, due to the removal of the need to administer
-VED, though the tax will fall more heavily on those who use more fuel, and thus create more
-carbon emissions.
+The 'Emissions Tax' will be applied at a flat rate at the pumps, and will be based upon typical combustion values in the UK and upon the estimated environmental impact that these gases create.
+
+The 'Road Strengthening Tax' will be applied at a variable rate to vehicles licensed to drive on public roads, and will be based upon power output.
+
+Vehicles which produce a lot of power (such as sporting vehicles) will pay a lot of tax for road maintenance. Vehicles which produce less power (such as small family cars) will pay less tax. Agricultural vehicles will continue to be provided with subsidies and exemptions.
+
+What this should do is bring the cost of fuel down, while however unfortunately bringing the cost of "road tax" up. This could lead to greater evasion and therefore decreased government transport revenue.
+
+The advantage though is that families who could not afford to buy fuel for heating, cooking or travel before would see the cost of fuel come down; as Fuel Duty, a regressive form of taxation (renamed to Emissions Tax), would be reduced.
 
 ## National Infrastructure Organisations
 

--- a/transport.md
+++ b/transport.md
@@ -2,6 +2,12 @@
 title: Transport
 ---
 
+## Removal of Fossil Fuels
+
+No petrol-powered vehicle may be sold or imported for the purposes of resale by businesses that bare a date of manufacture later than the year 2029. 
+
+The reselling of cars present in the UK prior to 2030 by an individual will remain legal and will be discouraged with scrapping incentives.
+
 ## Replace Vehicle Excise Duty and Fuel Duty
 
 'Vehicle Excise Duty' and 'Fuel Duty' will be replaced with an 'Emissions Tax' and 'Road Strengthening Tax' respectively.

--- a/transport.md
+++ b/transport.md
@@ -4,7 +4,7 @@ title: Transport
 
 ## Removal of Fossil Fuels
 
-No petrol-powered vehicle may be sold or imported for the purposes of resale by businesses that bare a date of manufacture later than the year 2029. 
+No petrol or petro-diesel powered vehicle may be sold or imported for the purposes of resale by businesses that bare a date of manufacture later than the year 2029. 
 
 The reselling of cars present in the UK prior to 2030 by an individual will remain legal and will be discouraged with scrapping incentives.
 


### PR DESCRIPTION
I'm trying it again!

Main changes from first edition:

1. Removed the ban on the sale of petrol cars by 2029, which involved getting the public on board with it in 12 years and also involved looking past the fact that you could import a petrol car from France or Germany, at which point the rule only deprives *UK* dealerships of them.

2. Changed the tax criteria from vehicle weight to power output. Yes, it's still based on anticipated use rather than actual use. Please see 'Transport Debate Needed' on why this is the case.

Why was power output chosen specifically? Well in summary because it's easier, but it'd be easier still to explain why I didn't choose the rest:

Tax on Weight:
Vehicle weight is constant per vehicle, but varies a lot between vehicles. The line in the sand would seem fairly arbitrary. Plus heavier cars are on average 25% safer. It's fine if weight shedding is used as part of a broader package of reaching better vehicle efficiency, but to encourage it through the tax system is perhaps unwise.

Tax on Power Capacity:
This is the equivalent of having vehicles with arbitrarily small tanks in them, just to avoid the taxes. You could easily fit a bigger tank, or in the case of electric vehicles a bigger battery reserve. It seemed pointless given this point to put a tax on vehicle power reserves based on how they rolled out of the factory.

Tax on Tyre Wear:
The best way to accurately measure how much your car has used the roads is to look at the tyres. Each time you buy fresh tyres, you would have to pay a lot of tax. When you hand in your old ones and they're shown to be not very worn, then you'd get a rebate. So in a way it encourages you to get fresh rubbers frequently. Safe, right? Well, even if you *forced* the poor to get fresh rubbers at the expense of food or rent, what is to stop those slightly better off from buying untaxed rubber overseas? You would need at the very least EU-wide consensus on car taxation. This option was ruled out.

Tax on Vehicle Class:
Some cars are recreational more than functional. Some cars are naturally heavier and cause more surface wear. But what about saloon cars or utility vehicles? Are they for work or pleasure? Will our tax system stay competitive with the rest of the world if someone could simply buy a sports car from France? It's yet another arbitrary line in the sand which no better relfects road wear than anything else.

Tax on Anticipated Road Wear:
The problem with a tax on this is that it's really hard to anticipate. Yes, HGVs do more damage, but does your business use them four hours a week or 24/7? Without a black box I couldn't know - I would have to take your word for it. Let me guess, you barely used it at all...

So here's why I chose Power Output:
Our current system is already based around power output. It's just a simple case of changing bhp to kilowatts. Powerful vehicles *tend* to be bigger, heavier, and cause more road wear than their little-powered cousins. The disadvantage to a power output tax was that, in Japan it was considered to stifle competitiveness in their design department. This was under the very unique situation that the Japanese tax system had created though. If ours is fairer, it need not punish too severely.

What says everyone?
Can I get this passed or what?