### PR TITLE
Contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # The OpenPolitics Manifesto
 
-This is an experiment in collaboratively creating a political movement.
-
-You can read the manifesto by looking at the [main website](http://openpolitics.org.uk).
+This is an experiment in collaboratively creating a political manifesto. You can [read and contribute to the manifesto online](http://openpolitics.org.uk/manifesto), and you can also take a look at the [list of proposals currently under discussion](https://votebot.openpolitics.org.uk/proposals).
 
 ## How to take part
 
-This repository stores the full text and history of the manifesto. Anyone can change or add something. See [the contributor guide](http://openpolitics.org.uk/contributing.html) for details on how to start making your own changes.
+Anyone can change or add something. Just visit the manifesto pages, and click "Suggest a change" to get involved.
 
-You can also raise issues in the [issue tracker](https://github.com/openpolitics/manifesto/issues) for things that you think need doing.
+See [the contributor guide](http://openpolitics.org.uk/manifesto/contributing.html) for full details on how it all works.
 
-## To Do
+## Ideas
 
-There are plenty of areas where we don't yet have anything in the manifesto. If you're looking to contribute but are unsure where to start, why not have a look at one of these areas? The [policy tag on the GitHub issues tracker](https://github.com/openpolitics/manifesto/labels/policy) has a load of ideas. Feel free to add your own too!
+There are plenty of areas where we don't yet have anything in the manifesto. If you're looking to contribute but are unsure where to start, why not have a look at the ideas list?
+ tracker](https://github.com/openpolitics/manifesto/labels/policy) has a load of ideas. 
+ 
+ Feel free to add your own too using the [issue form](https://github.com/openpolitics/manifesto/issues/new?labels=idea)!

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,51 @@
+---
+title: Code of Conduct
+layout: manifesto_page
+---
+
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as [contributors](https://votebot.openpolitics.org.uk/users) and [maintainers](https://github.com/orgs/openpolitics/teams/core) pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behaviour that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behaviour by participants include:
+
+* The use of sexualised language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+[Project maintainers](https://github.com/orgs/openpolitics/teams/core) are responsible for clarifying the standards of acceptable behaviour and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behaviour.
+
+[Project maintainers](https://github.com/orgs/openpolitics/teams/core) have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviours that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by [project maintainers](https://github.com/orgs/openpolitics/teams/core).
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at [abuse@openpolitics.org.uk](mailto:abuse@openpolitics.org.uk). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The [project team](https://github.com/orgs/openpolitics/teams/core) is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+[Project maintainers](https://github.com/orgs/openpolitics/teams/core) who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -43,6 +43,8 @@ Instances of abusive, harassing, or otherwise unacceptable behaviour may be repo
 
 [Project maintainers](https://github.com/orgs/openpolitics/teams/core) who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 
+Actions taken by the project maintainers under this Code of Conduct will be published publicly, explaining reasons and linking to sources wherever possible, while respecting the confidentiality of reporters as stated above.
+
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,90 @@
+---
+title: How to contribute
+layout: manifesto_page
+---
+
+# How to contribute
+
+This project is an open collaborative space, based on open source principles. That means anyone can get involved, and we can accept ideas from anywhere. This is a UK political manifesto, but you don't need to be a member of a party, of voting age, or even in the UK to contribute. Good ideas can come from anywhere!
+
+## Code of Conduct
+
+Firstly, this project has a [code of conduct](code_of_conduct.html). In the interest of fostering an open and welcoming environment, we as [contributors](https://votebot.openpolitics.org.uk/users) and [maintainers](https://github.com/orgs/openpolitics/teams/core) pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation. Read the [complete code of conduct](code_of_conduct.html) for the full policy, and to see what is expected of you as a contributor.
+
+## The Rules
+
+{::options parse_block_html="true" /}
+<div class='well'>
+
+* You can propose a change on *any* page with a suggest button - even the voting rules on this page.
+* All contributions and discussions should be public - no backroom deals!
+* Plain English is important - follow the [gov.uk style guide](https://www.gov.uk/guidance/content-design/writing-for-gov-uk) if you can, or use [Hemingway](http://hemingwayapp.com) to test readability. Avoid political weasel-words, especially.
+* Provide evidence and links wherever possible, to back up your case. Include them in your proposal text, either as direct links, or as footnotes.
+* Make your proposals small, self-contained, and simple. Large changes will take a lot longer to get agreed upon and merged. Small is agile.
+* Proposals don't need to be fully finished or hugely detailed. It's better to make small iterative improvements, as it keeps things moving faster.
+* All content is public domain. Please sign the [Contributor License Agreement](https://www.clahub.com/agreements/openpolitics/manifesto) when you make a contribution. See [the full license](license.html) for details.
+
+</div>
+
+## Editing
+
+1. Read the manifesto, and find the page you want to edit. Then click the `Suggest a change` button at the top right.
+2. Log in with a [GitHub account](https://github.com/signup/free); if you don't have one, you can make an account for free. GitHub is the system that stores all the changes made to the manifesto, so you need an account to contribute. Your account doesn't have to be linked to your real name or identity.
+3. Make your change in the editor. Text is formatted with Markdown; you'll find instructions at the side of the editor window.
+4. If this is your first edit, please agree to the [Contributor License Agreement](https://www.clahub.com/agreements/openpolitics/manifesto) to state that your submission is in the public domain.
+5. After you've saved your changes, your proposal will be enter the [proposal list](https://votebot.openpolitics.org.uk/proposals). There will then be a vote, and possibly debate, amongst contributors on whether to adopt the proposal. You can change the proposal in response to the discussion, if you want to.
+
+If you want to contribute but aren't sure what you can start with, you can check out the [ideas list](https://votebot.openpolitics.org.uk/ideas) for inspiration.
+
+## Voting
+
+We use a consensus voting system, where a change is accepted if it reaches a certain threshold of yes votes.
+
+People who have contributed to the manifesto are eligible to vote on proposals. If you get a proposal accepted, you will get a vote. It doesn't have to be a big change, as long as you contribute, you're in!
+
+The simplest way to vote is using the [voting interface](https://votebot.openpolitics.org.uk/proposals). Click on the proposal details to see the change, comment, or cast a vote.
+
+Three vote types are available:
+
+|vote|symbol|score|
+|--|--|--|
+|Yes|:white_check_mark:|1|
+|No|:negative_squared_cross_mark:|-1|
+|Block|:no_entry_sign:|-1000|
+{: .table .table-striped}
+
+### Counting votes
+
+When votes are cast, the score is counted up, and as long as the total is 2 or more, the proposal passes. If a change is amended, "yes" votes are reset, and are only counted if cast after the latest change.
+
+### Time
+
+Proposals must be open for a minimum of 7 days, and are rejected if they're not passed within 90 days.
+
+### Blocks
+
+Block votes are special, and are intended as a protection against fundamental changes being forced in through brigading. 
+
+If a change violates the core principles of the manifesto, any voter can use a block vote. The block vote should come with detailed reasoning and constructive comments for improvement if possible. A block can be removed by the original blocker changing to a yes or no vote. Blocks that are not explained can be overridden if enough voters agree, though this process is not strictly defined at present.
+
+Blocks are generally discouraged; if you disagree with a proposal in a normal way, just vote "no". Blocks should only be used in extreme circumstances, such as if a proposal completely violates the principles of the manifesto.
+
+## Advanced GitHub users
+
+If you're familiar with git and GitHub, you can use the standard fork / pull request flow to make your proposal. The repository is at [openpolitics/manifesto](https://github.com/openpolitics/manifesto).
+
+You can also cast votes directly in the GitHub pull request comments, using the symbols below:
+
+|vote|symbol|type this|
+|--|--|--|
+|Yes|:white_check_mark:|`:white_check_mark:`|
+|No|:negative_squared_cross_mark:|`:negative_squared_cross_mark:`|
+|Block|:no_entry_sign:|`:no_entry_sign:`|
+{: .table .table-striped}
+
+## Help
+
+* [GitHub Democracy](https://floppy.org.uk/blog/2014/10/13/github-democracy/) - James' blog post with more about this process
+* [General GitHub documentation](http://help.github.com/)
+* [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
+* [Markdown syntax reference](http://en.support.wordpress.com/markdown-quick-reference/)

--- a/license.md
+++ b/license.md
@@ -1,1 +1,26 @@
+---
+title: License
+layout: manifesto_page
+---
+
 The content of the OpenPolitics Manifesto is has been put into the public domain, using the CC0 1.0 Universal Public Domain Dedication.  See the [Creative Commons CC0 page](http://creativecommons.org/publicdomain/zero/1.0/) for more details.
+
+<div class="well" style='max-width: 500px; margin-left: auto; margin-right: auto; text-align: center'>
+  
+  <p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
+    <a rel="license" href="http://creativecommons.org/publicdomain/zero/1.0/"><img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" /></a>
+  </p>
+  <p>
+    To the extent possible under law,
+    <a rel="dct:publisher"
+       href="http://openpolitics.org.uk">
+      <span property="dct:title">The OpenPolitics Project</span></a>
+    has waived all copyright and related or neighboring rights to
+    <span property="dct:title">The OpenPolitics Manifesto</span>.
+  This work is published from the
+  <span property="vcard:Country" datatype="dct:ISO3166"
+        content="GB" about="http://openpolitics.org.uk/manifesto">
+    United Kingdom</span>.
+  </p>
+
+</div>


### PR DESCRIPTION
Bringing the contributing guide back into the manifesto repository itself. This is important because it contains the canonical statements of the voting rules, which should be changeable under the same system. They were moved out (wrongly) when the project was split into the manifesto and the wrapper website.

There are no changes here to policy or to the voting rules, but the guide has been updated from that at https://openpolitics.org.uk/contributing.html to reflect the current state of the votebot platform. I've also added the contributor covenant code of conduct.

Resolves #456 