### PR TITLE
Added sub section to improve competition and market operation

### DIFF
--- a/transport.md
+++ b/transport.md
@@ -72,6 +72,9 @@ Investigate feasibility of building a high speed rail network that connects our 
 
 Examine which areas of the United Kingdom were most detrimentally affected by the changes in the [Beeching Reports](https://en.wikipedia.org/wiki/Beeching_cuts), and whether it would be economically feasible to bring back any formerly established railways.
 
+Introduce true/genuine competition by allowing multiple operators on the same routes and replace the series of monopolies that currently exists. Operating licenses could be granted to companies operating at the level of single train (or even carriage) so that communities  can act to better serve local needs. 
+
+
 ## Bus
 
 Promote efficient use of road space in towns and cities by allocating road space to bus lanes, encouraging the creation of a network of frequent bus routes.


### PR DESCRIPTION
The initial privatisation of the railways did not result in free and fair competition. The single national monopoly (British Rail) was simply replaced by a series of private companies effectively operating monopolies on their routes. The only competition is when these operators bid for the rights to operate their monopoly. In contrast some other European countries introduced competition by allowing private operators to work in parallel with the national system. For example in Austria the passenger has the choice between multiple operators on the same route offering different prices, quality and speed. 

This proposal therefore seeks to have free and fair competition at the level the customer experiences and not just the level the Department of Transport experiences. Moreover, it would be done in a way that enables local communities to serve their own unique needs.    