### PR TITLE
(human-made) added to ownership

### DIFF
--- a/economy.md
+++ b/economy.md
@@ -101,4 +101,4 @@ information to the public in a similar manner as the property price paid data se
 requirement to register land option agreements, transactions and prices."
 
 ## Ownership
-When you buy something, it should be owned (not a license to use). A preventative measure to reduce risk of vendor lock-in and promote ability to fix and modify purchased products.
+When you buy something (human-made), it should be owned (not a license to use). A preventative measure to reduce risk of vendor lock-in and promote ability to fix and modify purchased products.


### PR DESCRIPTION
(human-made) added to ownership, as to distinguish property suceptible to be bought from the commons/public property which it is illegitimate to take away from the public owner & so public property can only be rented (never privatised, such as the sea, the water, space, wild life, the countryside, the road network) (all Land ownership has to be compensated by some form of LVT (even with an allowance, or with a relatively low starting rate) wherever the exclusive use of that Land is in private hands [no Land if its rental value is non-null should be exempted: even if the Land belong to a public entity with exclusive use: if it belong to the state/the UK, as crown dependencies, LVT is due to be paid to the council, if it belongs to the council, LVT is to be paid to the UK state]), not bought, and has to include all natural resources, including Land