### PR TITLE
Move toilet seat orientation from being no entry to earlier

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ We believe that government should be:
 
 We believe that individuals should:
 
-* Be treated equally by the law, regardless of gender identity, sex, romantic orientation, sexual orientation, ethnicity, race, perceived ethnicity and/or race, age, religious and/or spiritual belief, occupation (current or previous), status of union membership (including the type of union and what union), marital status, or disability.
+* Be treated equally by the law, regardless of gender identity, sex, romantic orientation, sexual orientation, ethnicity, race, perceived ethnicity and/or race, age, religious and/or spiritual belief, occupation (current or previous), status of union membership (including the type of union and what union), marital status, beer consumption, home game attendance, nose hair length, quietness, loudness, lack of interest in handbags, computer game high-score, using the last bacon rasher, slouching, gym or no gym membership, not caring about some scene out of the lion king, putting ones foot in it, snoring, toilet seat orientation, belief, or disability.
 * Be free to act in any manner that does not harm another individual, and does not infringe upon the rights of other individuals.
 * Enjoy a fundamental right to privacy from the state or their agents.
 


### PR DESCRIPTION
Joking aside, what I want you to understand is the egalitarian point of view. That to create lists of people is to discriminate between them; to select your favourites, and then to leave others out. The commitment to treat people fairly shouldn't end at this one category or another. Everyone we've over-looked counts for something. Even the bald men, they count too! Furthermore, it is very hard to oppose a party that offers freedom for all, without any exceptions. It's very easy to oppose one that offers to single me out (whether or not they aim to be favourable or unfavourable).

Perhaps I'm the only one who sees it, and perhaps I'm as unconvincing here as I was over the contributor guidelines earlier on. But this problem will get worse as policy after policy tries to be specific to some amongst others, until they become so large and incomprehensible, or until enough people see it in the same way.

Freedom for all - that is the point.