### PR TITLE
Resubmission: Adjustment to arms policy (further edits re: genocide)

### DIFF
--- a/foreign_policy.md
+++ b/foreign_policy.md
@@ -35,7 +35,9 @@ EU citizens currently resident in the UK should have a guaranteed right to remai
 
 ## Arms Trading
 
-Commit to ensuring that no British-built arms are sold to nations that are likely to use those arms against their own people, or to any other agent or third party that may do so.
+Commit to ensuring that no arms built in the United Kingdom of Britain and Northern Ireland and no arms owned by the state at any level of governance (within the U.K.o.B.N.I. system of governance of the day); are sold to nations that are likely to use those arms against their own people, or use those arms to commit something that could be considered genocide under The Convention on the Prevention and Punishment of the Crime of Genocide [^genocide], or to any other agent or third party that may do so.
+
+[^genocide]: The text of The Convention on the Prevention and Punishment of the Crime of Genocide: http://www.ohchr.org/EN/ProfessionalInterest/Pages/CrimeOfGenocide.aspx
 
 ## Nuclear Disarmament
 


### PR DESCRIPTION
Given our government reportedly is aiding genocide in Yemen, and is selling arms to Saudi Arabia, this is a very important policy to add.

Saudi committing genocide: https://www.rt.com/op-edge/380700-yemen-saudi-arabia-genocide/

UN report on how this is against international law: http://www.ohchr.org/EN/NewsEvents/Pages/DisplayNews.aspx?NewsID=21163&LangID=E#sthash.zjA0dW1Q.dpuf

We're selling Saudi Arabia weapons: https://www.theguardian.com/world/2016/sep/16/british-arms-sales-saudi-arabia-airstrikes-yemen-civilian-casualties

Oh Saudi once threatened us with terrorism, we're still selling them weapons: https://www.theguardian.com/world/2008/feb/15/bae.armstrade