### PR TITLE
Reduction of the Rationale in Tax Policy

### DIFF
--- a/economy.md
+++ b/economy.md
@@ -26,10 +26,6 @@ We must improve fairness in the tax system by closing tax evasion loopholes and 
 
 Tax laws and the tax system must be simplified. Much tax avoidance happens because the tax code is excessively complex and full of loopholes, so simplifying the system is a big step towards reducing avoidance.
 
-As a general rule of thumb, tax policy should focus on simple direct taxation (such as income tax, corporation tax and land value tax) for the bulk of revenue raising, and use minimal indirect taxes to discourage certain activities (such as fossil fuel use, drug use, and so on).
-
-Enable greater decentralisation of taxation by enabling local authorities to set tax rates according to local needs, keep those revenues and spend them according to local need. 
-
 ### Income Tax
 
 The personal income tax allowance will be set at the level of a full time living wage and will rise in line with the living wage. This means that someone working a normal full-time job at the minimum wage would not pay any income tax.


### PR DESCRIPTION
Ok here's the problem:
1. The "direct taxes" bit lists a bunch of taxes that lack justification - they're all taxes for the sake of being taxed. Originally I think they were used to fund some war with the French, but since then they've been operated as a "general taxation" and an excuse to take money without due cause. If you want to explain the way that you'll operate these taxes, you ought to come up with real reasons for them.

2. The "minimal indirect taxes to discourage certain activities" is equally unethical. Gentle nudging and hard shoving are the same thing by governments - they have no distinction. Taxes should be to pay one's due, not to be an experiment in social engineering or to encourage the poor to act differently.

3. "enabling local authorities to set tax rates according to local needs" will be an administrative burden and an excuse for them to fuck everyone over. I don't know about you being all politically involved and everything, but me, I've never elected a privy councillor before. It's the least exciting election along with the police commissioner and the mayoralship. Give them an inch, and they take a mile with new parking charges and bin collection taxes.

These justifications for operating these taxes the way that you do are really poor. Finally, I should say that they aren't actually policy. They're there to "inform policy". Which doesn't seem to have any use to me. Good policies will speak for themselves.

So I'm calling a vote to clear it out: yea or nae.