### PR TITLE
Partial Military Policy Revamp

### DIFF
--- a/military.md
+++ b/military.md
@@ -28,12 +28,6 @@ We will empower the SIA regulatory body to regulate private military and securit
 
 We will push for an international regulatory body and statutes for PMSCs around the world, possibly administered through the UN. The international body could potentially incorporate both the [Montreux Document](https://www.globalpolicy.org/images/pdfs/0917montreuxdocument.pdf) and the [International Code of Conduct for Private Security Service Providers](http://icoca.ch/sites/all/themes/icoca/assets/icoc_english3.pdf).
 
-## Proprietary Test Facilities
-
-We will ask all companies contracted to operate Ministry of Defence sites to separate their testing and evaluation businesses from their civil and military training businesses. 
-
-Contracts for MoD test facilities will then be allowed to expire and all weapons test grounds will return to public ownership, allowing weapons to be assessed based on their merits rather than profit incentive.
-
 ## Autonomous Weapon Systems
 
 We will petition the UN and other international bodies to create an amendment to the Geneva Convention banning the development and use of electrical autonomously discharged weapon systems, ensuring that "who pulls the trigger" is entrusted solely to human oversight.

--- a/military.md
+++ b/military.md
@@ -24,14 +24,16 @@ Reviews of defence budgets will be tied to a review of commitments, not just exp
 
 ## Private Military and Security Companies
 
-We will establish a regulatory body for private military and security companies (PMSC) registered in the UK. All PMSCs will be required to register with this body and they will then either receive approval to operate as a PMSC or not. PMSCs will have to seek approval with the regulatory body before accepting operational deployments. A list of private military contractors that are missing or killed whilst in the service of these PMSCs will also be collated and published annually.
+We will empower the SIA regulatory body to regulate private military and security companies (PMSCs) registered in the UK. All PMSCs will be required to register with this body, and they will then either receive approval to operate as a PMSC or not. PMSCs will have to seek approval with the regulatory body before accepting operational deployments. All approved operations will be a matter of public record, the full details of which will be published within 3 years. A list of private military contractors that are missing or killed whilst in the service of these PMSCs will also be collated and published quarterly.
 
 We will push for an international regulatory body and statutes for PMSCs around the world, possibly administered through the UN. The international body could potentially incorporate both the [Montreux Document](https://www.globalpolicy.org/images/pdfs/0917montreuxdocument.pdf) and the [International Code of Conduct for Private Security Service Providers](http://icoca.ch/sites/all/themes/icoca/assets/icoc_english3.pdf).
 
-## Lethal Autonomous Weapon Systems
+## Proprietary Test Facilities
 
-Giving machines the power to decide who lives and dies on the battlefield is an unacceptable and dangerous application of modern technology[^killer-robots]. Development of lethal autonomous weapon systems will be made illegal in the UK.
+We will ask all companies contracted to operate Ministry of Defence sites to separate their testing and evaluation businesses from their civil and military training businesses. 
 
-We will lead the UN and other international bodies to create an international treaty, similar to the Geneva Convention, banning the development and use of lethal autonomous weapon systems.
+Contracts for MoD test facilities will then be allowed to expire and all weapons test grounds will return to public ownership, allowing weapons to be assessed based on their merits rather than profit incentive.
 
-[^killer-robots]: Campaign to stop killer robots: [http://www.stopkillerrobots.org/the-solution/](http://www.stopkillerrobots.org/the-solution/)
+## Autonomous Weapon Systems
+
+We will petition the UN and other international bodies to create an amendment to the Geneva Convention banning the development and use of electrical autonomously discharged weapon systems, ensuring that "who pulls the trigger" is entrusted solely to human oversight.


### PR DESCRIPTION
Changes:
Security Industry Authority given the responsibility of managing PMSCs. 
Compulsory publication of all PMSC operations within 3 years (as in not just "Defence Inc - Iraq" but "Defence Inc - Helmand Province, Iraq Operational Objective: Etcetera").
Publication of killed/missing lists changed from annual to quarterly.
Return to public ownership of MoD site operation (not associated with runway/aircraft training).
"What is 'autonomous'?" is given a definition ("electrically autonomously discharged").
"Lethal" is removed - to prevent drones from autonomously firing tasers or CS gas.

If anyone has any problem with any of the changes then I can split them up and submit them separately.
Otherwise tell me what you want changed and I'll try to add it.