### PR TITLE
Private School's VAT Intro Dropped, Requirement to Admit Poor Students Instead

### DIFF
--- a/education.md
+++ b/education.md
@@ -54,7 +54,7 @@ Scottish authorities will no longer be legally obligated to appoint unelected re
 
 ## Private Schools
 
-We will remove the charitable status from private schools, and make fees subject to VAT, as private schooling is most certainly a luxury.
+Every paid-for student must in turn completely cover the bursary of a poor student, and in so doing maintain the anonymity of their benefactors. Thusly the ratio of rich to poor students in all private schools, shall be 50:50.
 
 ## Discrimination in Physical Education
 


### PR DESCRIPTION
I couldn't think of a better way to write it ~ no "economically disadvantaged" euphemisms were included.

The old policy of introducing VAT wouldn't break up the cronyism and the old guard. I don't think it'd hit their profits either really. People will pay whatever they're asked for, for the right colour tie. It was simply an exercise in the state taking some of the money from it as a profitable business.

Well, I've made it so that to make a profit they have to help the country's poor to do it. oops.
"Complete subsidy" must be adequately enforced too. Otherwise you'll get Eton boys wearing an "even fancier (unsubsidised) tie" so long as it distinguishes them from the great unwashed.

Also, education is not a luxury. Even if you're giving English lessons to the shah of Saudi Arabia it's not a luxury. I don't think they should pay "what ought to be due" for "the sin of teaching English". Even if that's a lucrative profession for them.
