### PR TITLE
Replace Vehicle Excise Duty and Fuel Duty: The Trilogy

### DIFF
--- a/transport.md
+++ b/transport.md
@@ -8,7 +8,7 @@ No road vehicle powered solely from the use of a petrol or diesel engine may be 
 
 ## Taxi Services
 
-We will incentivise taxi companies to buy taxis with lower or zero carbon emissions via tax reductions on the company's profits, scaled in a carbon brackets system that takes business size, current carbon output, carbon reductions made within the year, and the starting point for having entered the scheme into account.
+We will incentivise taxi companies to buy taxis with lower or zero carbon emissions via tax reductions on the company's profits, scaled in a carbon-bracket system that takes business size, current carbon output, carbon reductions made within the year, and the starting point for having entered the scheme into account.
 
 We will gather this data via mandating monthly inventory and accounts logging for businesses that enter the scheme, and by conducting random checks on the various businesses. This scheme would not be mandatory for business to enter into, but would allow them to openly publicize that they had joined the scheme as a means of marketing their business.
 

--- a/transport.md
+++ b/transport.md
@@ -18,7 +18,7 @@ An 'Emissions Tax' will be applied at a flat rate at the pumps, and will be base
 
 A 'Road Strengthening Tax' will be applied at a variable rate to vehicles licensed to drive on public roads, and will be based on power output (specifically; "the maximum continuous output obtainable by the main driving motor").
 
-Subsequently, hybrid cars (such as this one) will be taxed according to their single most powerful motor rather than for every motor's sum total within a vehicle.
+Subsequently, hybrid cars (such as [(this one) https://carnewschina.com/2017/02/21/byd-launches-the-tang-100-hybrid-super-suv-in-china/]) will be taxed according to their single most powerful motor rather than for every motor's sum total within a vehicle.
 
 A 'Traffic Improvement Tax' will be applied to all vehicles with an initial purchase price greater than £40,000.
 

--- a/transport.md
+++ b/transport.md
@@ -8,7 +8,7 @@ No road vehicle powered solely from the use of a petrol or diesel engine may be 
 
 ## Taxi Services
 
-We will incentivise taxi companies to buy taxis with lower carbon emissions and none, via tax reductions on the company profits, scaled in a bracket system that takes business size, current carbon output, the carbon reductions made within the year, and the starting point when the entering the scheme into account when calculating the tax reduction. We will gather this data via mandating monthly inventory and accounts logging for businesses that enter the scheme, and by conducting random checks on the various businesses. This scheme would not be mandatory for business to enter into, but would allow them to openly publicise that they had joined the scheme as a means of marketing their business.
+We will incentivise taxi companies to buy taxis with lower carbon emissions and none, via tax reductions on the company profits, scaled in a bracket system that takes business size, current carbon output, the carbon reductions made within the year, and the starting point when the entering the scheme into account when calculating the tax reduction. We will gather this data via mandating monthly inventory and accounts logging for businesses that enter the scheme, and by conducting random checks on the various businesses. This scheme would not be mandatory for business to enter into, but would allow them to openly publicize that they had joined the scheme as a means of marketing their business.
 
 ## Replacement of Vehicle Excise Duty and Electric Vehicle Exemptions
 

--- a/transport.md
+++ b/transport.md
@@ -4,29 +4,41 @@ title: Transport
 
 ## Removal of Fossil Fuels
 
-No new fossil-fuel powered vehicles may be sold in the UK after 2029.
+No road vehicle powered solely from the use of a petrol or diesel engine may be bought, sold in or imported into the UK bearing a date of manufacture later than the year 2029.
 
 ## Taxi Services
 
-We will incentivise taxi companies to buy taxis with lower carbon emissions and none, via tax reductions on the company profits, scaled in a bracket system that takes business size, current carbon output, the carbon reductions made within the year, and the starting point when the entering the scheme into account when calculating the tax reduction. We will gather this data via mandating monthly inventory and accounts logging for businesses that enter the scheme, and by conducting random checks on the various businesses. This scheme would not be mandatory for business to enter into, but would allow them to openly publicize that they had joined the scheme as a means of marketing their business.
+We will incentivise taxi companies to buy taxis with lower or zero carbon emissions via tax reductions on the company's profits, scaled in a carbon brackets system that takes business size, current carbon output, carbon reductions made within the year, and the starting point for having entered the scheme into account.
 
-## Scrap Vehicle Excise Duty
+We will gather this data via mandating monthly inventory and accounts logging for businesses that enter the scheme, and by conducting random checks on the various businesses. This scheme would not be mandatory for business to enter into, but would allow them to openly publicize that they had joined the scheme as a means of marketing their business.
 
-As Vehicle Excise Duty is associated with vehicle emissions, it seems fairer to tax
-the fuel directly. VED should be scrapped, and fuel duty increased to cover the reduction
-in income. Overall, the tax levied should be lower, due to the removal of the need to administer
-VED, though the tax will fall more heavily on those who use more fuel, and thus create more
-carbon emissions.
+## Replacement of Vehicle Excise Duty and Electric Vehicle Exemptions
+
+'Vehicle Excise Duty' and 'Fuel Duty' will be replaced with an 'Emissions Tax' and 'Road Strengthening Tax' respectively. A 'Traffic Improvement Tax' will additionally be collected within the "luxury" segment of the transport industry.
+
+An 'Emissions Tax' will be applied at a flat rate at the pumps, and will be based on typical combustion values in the UK and upon the estimated environmental impact that these gases create.
+
+A 'Road Strengthening Tax' will be applied at a variable rate to vehicles licensed to drive on public roads, and will be based on power output (specifically; "the maximum continuous output obtainable by the main driving motor").
+
+Subsequently, hybrid cars (such as this one) will be taxed according to their single most powerful motor rather than for every motor's sum total within a vehicle.
+
+A 'Traffic Improvement Tax' will be applied to all vehicles with an initial purchase price greater than £40,000.
+
+Electric-only vehicles will be exempt from the taxes detailed here until such a time as their adoption becomes widespread.
+
+What this should do is bring the cost of fuel down, while however unfortunately bringing the cost of "road tax" up. This could lead to greater evasion and therefore decreased government transport revenue.
+
+The advantage though is that families who could not afford to buy fuel for heating, cooking or travel before would see the cost of fuel come down; as Fuel Duty, a regressive form of taxation (renamed to Emissions Tax), would be reduced.
 
 ## National Infrastructure Organisations
 
 Network Rail, the Highways Agency, train operating companies and bus operating companies would all be required to become [National Infrastructure Organisations (NIOs)](infrastructure.html) under a policy to ensure that infrastructure which is essential to a functioning society is not solely operated for the benefit of private shareholders, but in the national interest.
 
-## End UK airport expansion
+## End UK Airport Expansion
 
 Until the aviation industry is carbon neutral, there will be no further expansions (such as new runways or terminals) of any UK airports, and capacity shall be capped at roughly current levels.
 
-## Get rid of Nude Body Scanners
+## Get Rid of Nude Body Scanners
 
 We believe that other technologies and solutions exist that are able to better serve transport authorities in carrying out their responsibility in the interests of airport and national security.
 
@@ -72,6 +84,6 @@ Investigate feasibility of building a high speed rail network that connects our 
 
 Examine which areas of the United Kingdom were most detrimentally affected by the changes in the [Beeching Reports](https://en.wikipedia.org/wiki/Beeching_cuts), and whether it would be economically feasible to bring back any formerly established railways.
 
-## Bus
+## Buses
 
 Promote efficient use of road space in towns and cities by allocating road space to bus lanes, encouraging the creation of a network of frequent bus routes.

--- a/transport.md
+++ b/transport.md
@@ -8,9 +8,7 @@ No road vehicle powered solely from the use of a petrol or diesel engine may be 
 
 ## Taxi Services
 
-We will incentivise taxi companies to buy taxis with lower or zero carbon emissions via tax reductions on the company's profits, scaled in a carbon-bracket system that takes business size, current carbon output, carbon reductions made within the year, and the starting point for having entered the scheme into account.
-
-We will gather this data via mandating monthly inventory and accounts logging for businesses that enter the scheme, and by conducting random checks on the various businesses. This scheme would not be mandatory for business to enter into, but would allow them to openly publicize that they had joined the scheme as a means of marketing their business.
+We will incentivise taxi companies to buy taxis with lower or zero carbon emissions via tax reductions on the company's profits, scaled in a carbon-bracket system that takes business size, current carbon output, carbon reductions made within the year, and the starting point for having entered the scheme into account. We will gather this data via mandating monthly inventory and accounts logging for businesses that enter the scheme, and by conducting random checks on the various businesses. This scheme would not be mandatory for business to enter into, but would allow them to openly publicize that they had joined the scheme as a means of marketing their business.
 
 ## Replacement of Vehicle Excise Duty and Electric Vehicle Exemptions
 

--- a/transport.md
+++ b/transport.md
@@ -8,7 +8,7 @@ No road vehicle powered solely from the use of a petrol or diesel engine may be 
 
 ## Taxi Services
 
-We will incentivise taxi companies to buy taxis with lower or zero carbon emissions via tax reductions on the company's profits, scaled in a carbon-bracket system that takes business size, current carbon output, carbon reductions made within the year, and the starting point for having entered the scheme into account. We will gather this data via mandating monthly inventory and accounts logging for businesses that enter the scheme, and by conducting random checks on the various businesses. This scheme would not be mandatory for business to enter into, but would allow them to openly publicize that they had joined the scheme as a means of marketing their business.
+We will incentivise taxi companies to buy taxis with lower carbon emissions and none, via tax reductions on the company profits, scaled in a bracket system that takes business size, current carbon output, the carbon reductions made within the year, and the starting point when the entering the scheme into account when calculating the tax reduction. We will gather this data via mandating monthly inventory and accounts logging for businesses that enter the scheme, and by conducting random checks on the various businesses. This scheme would not be mandatory for business to enter into, but would allow them to openly publicize that they had joined the scheme as a means of marketing their business.
 
 ## Replacement of Vehicle Excise Duty and Electric Vehicle Exemptions
 

--- a/transport.md
+++ b/transport.md
@@ -8,13 +8,13 @@ No road vehicle powered solely from the use of a petrol or diesel engine may be 
 
 ## Taxi Services
 
-We will incentivise taxi companies to buy taxis with lower carbon emissions and none, via tax reductions on the company profits, scaled in a bracket system that takes business size, current carbon output, the carbon reductions made within the year, and the starting point when the entering the scheme into account when calculating the tax reduction. We will gather this data via mandating monthly inventory and accounts logging for businesses that enter the scheme, and by conducting random checks on the various businesses. This scheme would not be mandatory for business to enter into, but would allow them to openly publicize that they had joined the scheme as a means of marketing their business.
+We will incentivise taxi companies to buy taxis with lower carbon emissions and none, via tax reductions on the company profits, scaled in a bracket system that takes business size, current carbon output, the carbon reductions made within the year, and the starting point when the entering the scheme into account when calculating the tax reduction. We will gather this data via mandating monthly inventory and accounts logging for businesses that enter the scheme, and by conducting random checks on the various businesses. This scheme would not be mandatory for business to enter into, but would allow them to openly publicise that they had joined the scheme as a means of marketing their business.
 
 ## Replacement of Vehicle Excise Duty and Electric Vehicle Exemptions
 
 'Vehicle Excise Duty' and 'Fuel Duty' will be replaced with an 'Emissions Tax' and 'Road Strengthening Tax' respectively. A 'Traffic Improvement Tax' will additionally be collected within the "luxury" segment of the transport industry.
 
-An 'Emissions Tax' will be applied at a flat rate at the pumps, and will be based on typical combustion values in the UK and upon the estimated environmental impact that these gases create.
+An 'Emissions Tax' will be applied at a flat rate at the pumps, and will be based upon typical combustion values in the UK and upon the estimated environmental impact that these gases create.
 
 A 'Road Strengthening Tax' will be applied at a variable rate to vehicles licensed to drive on public roads, and will be based on power output (specifically; "the maximum continuous output obtainable by the main driving motor").
 

--- a/transport.md
+++ b/transport.md
@@ -18,7 +18,7 @@ An 'Emissions Tax' will be applied at a flat rate at the pumps, and will be base
 
 A 'Road Strengthening Tax' will be applied at a variable rate to vehicles licensed to drive on public roads, and will be based on power output (specifically; "the maximum continuous output obtainable by the main driving motor").
 
-Subsequently, hybrid cars (such as [(this one) https://carnewschina.com/2017/02/21/byd-launches-the-tang-100-hybrid-super-suv-in-china/]) will be taxed according to their single most powerful motor rather than for every motor's sum total within a vehicle.
+Subsequently, hybrid cars (such as [this one](https://carnewschina.com/2017/02/21/byd-launches-the-tang-100-hybrid-super-suv-in-china/)) will be taxed according to their single most powerful motor rather than for every motor's sum total within a vehicle.
 
 A 'Traffic Improvement Tax' will be applied to all vehicles with an initial purchase price greater than £40,000.
 


### PR DESCRIPTION
Let me give you an idea of what this does:
1. Stops hydrogen and ethanol alternatives from being mistargeted under 'fossil fuels', so you are allowed these.
2. Permits hybrid cars and tractors.
3. This line's particular eloquence ("maximum continous output of the main driving motor") ensures that:
3A. Multiple driven axles aren't penalised by the tax system (you can have 4x100kW and you will only be charged for one 100kW).
3B. Allows apples to apples comparison of vehicles, as the spec sheet details typical kW output of the motor(s) rather than short-term output that would drain the battery source in under 15 minutes.
3C. Permits temporary under/over-volting, which simply won't be of any concern to the taxman unless you want to re-register your vehicle with the changed values.

It offers a great many incentives to go electric. It takes a system as complicated [as this](https://en.wikipedia.org/wiki/Vehicle_Excise_Duty) and explains it within roughly six paragraphs. I defy you to find a better system anywhere [within here](https://en.wikipedia.org/wiki/Road_tax)...

That said, I'm mainly pleased because it's not a copy-paste policy. It's not just "let's do this". It was hammer-and-chisel effort.

So yeah I'm pleased with it. But your scrutiny, please!